### PR TITLE
Unit tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,10 +36,16 @@ jobs:
 
       - name: "Setup Ninja"
         uses: seanmiddleditch/gha-setup-ninja@master
-        
+
+      - name: "Clone vcpkg"
+        uses: actions/checkout@v4
+        with:
+          repository: microsoft/vcpkg
+          path: vcpkg
+
       - name: Build
         run: |
-          cmake --preset ${{ matrix.cmake-preset }}
+          cmake --preset ${{ matrix.cmake-preset }} -DCMAKE_TOOLCHAIN_FILE="${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
           cmake --build --preset ${{ matrix.cmake-preset }}-release
         working-directory: ${{ github.workspace }}
       

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ include(GNUInstallDirs)
 include(CMakeDependentOption)
 
 option(TKRZW_TOOLS "Build cli frontends" OFF)
-cmake_dependent_option(TKRZW_TESTS "Generate a test target" OFF "TKRZW_TOOLS" OFF)
+option(TKRZW_TESTS "Build unit tests (requires gtest)" OFF)
+cmake_dependent_option(TKRZW_RUN_TOOLS "Generate a test target" OFF "TKRZW_TOOLS" OFF)
 
 
 find_package(Threads)
@@ -130,17 +131,21 @@ target_sources(tkrzw PRIVATE
     tkrzw_langc.cc
 )
 
+function(TkrzwAddExecutable)
+    cmake_parse_arguments(params "" "NAME" "SOURCES;LIBRARIES" ${ARGN})
+    add_executable(${params_NAME})
+    target_sources(${params_NAME} PRIVATE ${params_SOURCES})
+    target_link_libraries(${params_NAME} PRIVATE tkrzw ${params_LIBRARIES})
+    set_target_properties(${params_NAME} PROPERTIES MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>$<IF:$<STREQUAL:$<TARGET_PROPERTY:tkrzw,TYPE>,SHARED_LIBRARY>,DLL,>)
+endfunction()
+
+function(TkrzwAddCommandLineTool)
+    TkrzwAddExecutable(${ARGV})
+    set(TOOL_TARGETS ${TOOL_TARGETS} ${params_NAME} PARENT_SCOPE)
+endfunction()
+
 set(TOOL_TARGETS)
 if (TKRZW_TOOLS)
-    function(TkrzwAddCommandLineTool)
-        cmake_parse_arguments(params "" "NAME" "SOURCES" ${ARGN})
-        add_executable(${params_NAME})
-        target_sources(${params_NAME} PRIVATE ${params_SOURCES})
-        target_link_libraries(${params_NAME} PRIVATE tkrzw)
-        set_target_properties(${params_NAME} PROPERTIES MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>$<IF:$<STREQUAL:$<TARGET_PROPERTY:tkrzw,TYPE>,SHARED_LIBRARY>,DLL,>)
-        set(TOOL_TARGETS ${TOOL_TARGETS} ${params_NAME} PARENT_SCOPE)
-    endfunction()
-
     TkrzwAddCommandLineTool(NAME tkrzw_build_util SOURCES tkrzw_build_util.cc)
     TkrzwAddCommandLineTool(NAME tkrzw_str_perf SOURCES tkrzw_str_perf.cc)
     TkrzwAddCommandLineTool(NAME tkrzw_file_perf SOURCES tkrzw_file_perf.cc)
@@ -180,10 +185,20 @@ install(
     share/cmake/${CMAKE_PROJECT_NAME}
 )
 
-
-
-
 if (TKRZW_TESTS)
+    enable_testing()
+    find_package(GTest CONFIG REQUIRED)
+    
+    set(TEST_NAMES tkrzw_sys_config_test tkrzw_lib_common_test tkrzw_str_util_test tkrzw_hash_util_test tkrzw_time_util_test tkrzw_thread_util_test tkrzw_logger_test tkrzw_compress_test tkrzw_containers_test tkrzw_key_comparators_test tkrzw_file_util_test tkrzw_file_std_test tkrzw_file_mmap_test tkrzw_file_pos_test tkrzw_file_poly_test tkrzw_message_queue_test tkrzw_dbm_common_impl_test tkrzw_dbm_ulog_test tkrzw_dbm_hash_impl_test tkrzw_dbm_tree_impl_test tkrzw_dbm_tree_test tkrzw_dbm_hash_test tkrzw_dbm_skip_impl_test tkrzw_dbm_skip_test tkrzw_dbm_tiny_test tkrzw_dbm_baby_test tkrzw_dbm_cache_test tkrzw_dbm_std_test tkrzw_dbm_poly_test tkrzw_dbm_shard_test tkrzw_dbm_async_test tkrzw_index_test tkrzw_cmd_util_test tkrzw_langc_test)
+    foreach(text_name IN LISTS TEST_NAMES)
+        TkrzwAddExecutable(NAME ${text_name} SOURCES ${text_name}.cc LIBRARIES GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
+        add_test(NAME ${text_name} COMMAND ${text_name})
+    endforeach()
+endif (TKRZW_TESTS)
+
+
+
+if (TKRZW_RUN_TOOLS)
     enable_testing()
     add_test(NAME check-build-util:1 COMMAND tkrzw_build_util version)
     add_test(NAME check-build-util:2 COMMAND tkrzw_build_util config)
@@ -341,5 +356,5 @@ if (TKRZW_TESTS)
         set_tests_properties(check-hashdbm-util:${index} PROPERTIES DEPENDS check-hashdbm-util:${previous_index})
     endforeach()
 
-endif (TKRZW_TESTS)
+endif (TKRZW_RUN_TOOLS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,8 @@ if (TKRZW_TESTS)
     enable_testing()
     find_package(GTest CONFIG REQUIRED)
     
-    set(TEST_NAMES tkrzw_sys_config_test tkrzw_lib_common_test tkrzw_str_util_test tkrzw_hash_util_test tkrzw_time_util_test tkrzw_thread_util_test tkrzw_logger_test tkrzw_compress_test tkrzw_containers_test tkrzw_key_comparators_test tkrzw_file_util_test tkrzw_file_std_test tkrzw_file_mmap_test tkrzw_file_pos_test tkrzw_file_poly_test tkrzw_message_queue_test tkrzw_dbm_common_impl_test tkrzw_dbm_ulog_test tkrzw_dbm_hash_impl_test tkrzw_dbm_tree_impl_test tkrzw_dbm_tree_test tkrzw_dbm_hash_test tkrzw_dbm_skip_impl_test tkrzw_dbm_skip_test tkrzw_dbm_tiny_test tkrzw_dbm_baby_test tkrzw_dbm_cache_test tkrzw_dbm_std_test tkrzw_dbm_poly_test tkrzw_dbm_shard_test tkrzw_dbm_async_test tkrzw_index_test tkrzw_cmd_util_test tkrzw_langc_test)
+    # tkrzw_langc_test loads lots of variables from tkrzw.dll, which isn't implemented yet.
+    set(TEST_NAMES tkrzw_sys_config_test tkrzw_lib_common_test tkrzw_str_util_test tkrzw_hash_util_test tkrzw_time_util_test tkrzw_thread_util_test tkrzw_logger_test tkrzw_compress_test tkrzw_containers_test tkrzw_key_comparators_test tkrzw_file_util_test tkrzw_file_std_test tkrzw_file_mmap_test tkrzw_file_pos_test tkrzw_file_poly_test tkrzw_message_queue_test tkrzw_dbm_common_impl_test tkrzw_dbm_ulog_test tkrzw_dbm_hash_impl_test tkrzw_dbm_tree_impl_test tkrzw_dbm_tree_test tkrzw_dbm_hash_test tkrzw_dbm_skip_impl_test tkrzw_dbm_skip_test tkrzw_dbm_tiny_test tkrzw_dbm_baby_test tkrzw_dbm_cache_test tkrzw_dbm_std_test tkrzw_dbm_poly_test tkrzw_dbm_shard_test tkrzw_dbm_async_test tkrzw_index_test tkrzw_cmd_util_test)
     foreach(text_name IN LISTS TEST_NAMES)
         TkrzwAddExecutable(NAME ${text_name} SOURCES ${text_name}.cc LIBRARIES GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
         add_test(NAME ${text_name} COMMAND ${text_name})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -59,12 +59,16 @@
   ],
   "testPresets": [
     {
-      "name": "ninja-release",
-      "configurePreset": "ninja",
-      "configuration": "Release",
+      "name": "test-base",
       "output": {
         "verbosity": "extra"
       }
+    },
+    {
+      "name": "ninja-release",
+      "configurePreset": "ninja",
+      "configuration": "Release",
+      "inherits": ["test-base"]
     },
     {
       "name": "ninja-debug",
@@ -75,9 +79,7 @@
       "name": "msvc-release",
       "configurePreset": "msvc",
       "configuration": "Release",
-      "output": {
-        "verbosity": "extra"
-      }
+      "inherits": ["test-base"]
     },
     {
       "name": "msvc-debug",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -65,7 +65,8 @@
       },
       "output": {
         "verbosity": "extra"
-      }
+      },
+      "hidden": true
     },
     {
       "name": "ninja-release",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -60,6 +60,9 @@
   "testPresets": [
     {
       "name": "test-base",
+      "execution": {
+        "timeout": 10
+      },
       "output": {
         "verbosity": "extra"
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,6 @@
       "name": "base",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
-        "BUILD_SHARED_LIBS": "ON",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "CMAKE_VERBOSE_MAKEFILE": "ON",
         "TKRZW_TOOLS": "ON",

--- a/tkrzw_dbm_async_test.cc
+++ b/tkrzw_dbm_async_test.cc
@@ -148,18 +148,18 @@ TEST(AsyncDBMTest, Basic) {
     EXPECT_EQ(tkrzw::Status::SUCCESS,
               async.CompareExchange("a", "4567", std::string_view()).get());
     EXPECT_EQ(tkrzw::Status::INFEASIBLE_ERROR,
-              async.CompareExchange("a", tkrzw::DBM::ANY_DATA, "abc").get());
+              async.CompareExchange("a", tkrzw::DBM::GetMagicAnyDataId(), "abc").get());
     EXPECT_EQ(tkrzw::Status::SUCCESS,
               async.CompareExchange("a", std::string_view(), "abc").get());
     EXPECT_EQ("abc", dbm.GetSimple("a"));
     EXPECT_EQ(tkrzw::Status::SUCCESS,
-              async.CompareExchange("a", tkrzw::DBM::ANY_DATA, "def").get());
+              async.CompareExchange("a", tkrzw::DBM::GetMagicAnyDataId(), "def").get());
     EXPECT_EQ("def", dbm.GetSimple("a"));
     EXPECT_EQ(tkrzw::Status::SUCCESS,
-              async.CompareExchange("a", tkrzw::DBM::ANY_DATA, tkrzw::DBM::ANY_DATA).get());
+              async.CompareExchange("a", tkrzw::DBM::GetMagicAnyDataId(), tkrzw::DBM::GetMagicAnyDataId()).get());
     EXPECT_EQ("def", dbm.GetSimple("a"));
     EXPECT_EQ(tkrzw::Status::SUCCESS,
-              async.CompareExchange("a", tkrzw::DBM::ANY_DATA, std::string_view()).get());
+              async.CompareExchange("a", tkrzw::DBM::GetMagicAnyDataId(), std::string_view()).get());
     EXPECT_EQ("", dbm.GetSimple("a"));
     EXPECT_EQ(tkrzw::Status::SUCCESS, async.Increment("b", 2, 100).get().first);
     EXPECT_EQ(105, async.Increment("b", 3, 100).get().second);
@@ -197,15 +197,15 @@ TEST(AsyncDBMTest, Basic) {
     EXPECT_EQ(tkrzw::Status::SUCCESS, async.CompareExchangeMulti(
         kv_list({{"4", "hello"}}), kv_list({{"4", std::string_view()}})).get());
     EXPECT_EQ(tkrzw::Status::INFEASIBLE_ERROR, async.CompareExchangeMulti(
-        kv_list({{"xyz", tkrzw::DBM::ANY_DATA}}), kv_list({{"xyz", "abc"}})).get());
+        kv_list({{"xyz", tkrzw::DBM::GetMagicAnyDataId()}}), kv_list({{"xyz", "abc"}})).get());
     EXPECT_EQ(tkrzw::Status::SUCCESS, async.CompareExchangeMulti(
         kv_list({{"xyz", std::string_view()}}), kv_list({{"xyz", "abc"}})).get());
     EXPECT_EQ("abc", async.Get("xyz").get().second);
     EXPECT_EQ(tkrzw::Status::SUCCESS, async.CompareExchangeMulti(
-        kv_list({{"xyz", tkrzw::DBM::ANY_DATA}}), kv_list({{"xyz", "def"}})).get());
+        kv_list({{"xyz", tkrzw::DBM::GetMagicAnyDataId()}}), kv_list({{"xyz", "def"}})).get());
     EXPECT_EQ("def", async.Get("xyz").get().second);
     EXPECT_EQ(tkrzw::Status::SUCCESS, async.CompareExchangeMulti(
-        kv_list({{"xyz", tkrzw::DBM::ANY_DATA}}), kv_list({{"xyz", std::string_view()}})).get());
+        kv_list({{"xyz", tkrzw::DBM::GetMagicAnyDataId()}}), kv_list({{"xyz", std::string_view()}})).get());
     EXPECT_EQ("", async.Get("xyz").get().second);
   }
   {
@@ -272,7 +272,7 @@ TEST(AsyncDBMTest, Process) {
     EXPECT_EQ("one", r2.second->GetOldValue());
     std::string old_value;
     auto r3 = async.Process("b", [&](std::string_view key, std::string_view value) {
-                                   if (value.data() != tkrzw::DBM::RecordProcessor::NOOP.data()) {
+                                   if (value.data() != tkrzw::DBM::RecordProcessor::GetMagicNoOpId().data()) {
                                      old_value = value;
                                    }
                                    return "uno";
@@ -280,7 +280,7 @@ TEST(AsyncDBMTest, Process) {
     EXPECT_EQ(tkrzw::Status::SUCCESS, r3);
     EXPECT_EQ("", old_value);
     auto r4 = async.Process("b", [&](std::string_view key, std::string_view value) {
-                                   if (value.data() != tkrzw::DBM::RecordProcessor::NOOP.data()) {
+                                   if (value.data() != tkrzw::DBM::RecordProcessor::GetMagicNoOpId().data()) {
                                      old_value = value;
                                    }
                                    return "dos";
@@ -291,8 +291,8 @@ TEST(AsyncDBMTest, Process) {
      public:
       Bracketter() {}
       std::string_view ProcessFull(std::string_view key, std::string_view value) override {
-        if (value.data() == tkrzw::DBM::RecordProcessor::NOOP.data()) {
-          return tkrzw::DBM::RecordProcessor::NOOP;
+        if (value.data() == tkrzw::DBM::RecordProcessor::GetMagicNoOpId().data()) {
+          return tkrzw::DBM::RecordProcessor::GetMagicNoOpId();
         }
         new_value_ = tkrzw::StrCat("[", value, "]");
         return new_value_;
@@ -305,8 +305,8 @@ TEST(AsyncDBMTest, Process) {
     std::string new_value;
     auto r6 = async.ProcessEach([&](
         std::string_view key, std::string_view value) -> std::string_view {
-                                  if (value.data() == tkrzw::DBM::RecordProcessor::NOOP.data()) {
-                                    return tkrzw::DBM::RecordProcessor::NOOP;
+                                  if (value.data() == tkrzw::DBM::RecordProcessor::GetMagicNoOpId().data()) {
+                                    return tkrzw::DBM::RecordProcessor::GetMagicNoOpId();
                                   }
                                   new_value = tkrzw::StrCat("(", value, ")");
                                   return new_value;
@@ -340,7 +340,7 @@ TEST(AsyncDBMTest, Process) {
         std::string_view key, std::string_view value) -> std::string_view {
                                   first_key = key;
                                   first_value = value;
-                                  return tkrzw::DBM::RecordProcessor::NOOP;
+                                  return tkrzw::DBM::RecordProcessor::GetMagicNoOpId();
                                 }, true).get();
     EXPECT_EQ(tkrzw::Status::SUCCESS, r9);
     EXPECT_EQ("!!", first_key);

--- a/tkrzw_dbm_cache_test.cc
+++ b/tkrzw_dbm_cache_test.cc
@@ -123,6 +123,7 @@ TEST_F(CacheDBMTest, LRURemove) {
     const int32_t least_significant_byte = i % 256;
     const std::string least_significant_byte_key = tkrzw::ToString(least_significant_byte);
     EXPECT_EQ(tkrzw::ToString(least_significant_byte * least_significant_byte), dbm.GetSimple(least_significant_byte_key));
+    small;
   }
   for (int32_t i = 0; i < 4096; i++) {
     const std::string key = tkrzw::ToString(i);

--- a/tkrzw_dbm_cache_test.cc
+++ b/tkrzw_dbm_cache_test.cc
@@ -120,9 +120,9 @@ TEST_F(CacheDBMTest, LRURemove) {
     const std::string key = tkrzw::ToString(i);
     const std::string value = tkrzw::ToString(i * i);
     EXPECT_EQ(tkrzw::Status::SUCCESS, dbm.Set(key, value, false));
-    const int32_t small = i % 256;
-    const std::string small_key = tkrzw::ToString(small);
-    EXPECT_EQ(tkrzw::ToString(small * small), dbm.GetSimple(small_key));
+    const int32_t least_significant_byte = i % 256;
+    const std::string least_significant_byte_key = tkrzw::ToString(least_significant_byte);
+    EXPECT_EQ(tkrzw::ToString(least_significant_byte * least_significant_byte), dbm.GetSimple(least_significant_byte_key));
   }
   for (int32_t i = 0; i < 4096; i++) {
     const std::string key = tkrzw::ToString(i);

--- a/tkrzw_dbm_hash_impl_test.cc
+++ b/tkrzw_dbm_hash_impl_test.cc
@@ -135,11 +135,11 @@ TEST(DBMHashImplTest, HashRecord) {
          public:
           std::string_view ProcessFull(std::string_view key, std::string_view value) override {
             count_++;
-            return NOOP;
+            return GetMagicNoOpId();
           }
           std::string_view ProcessEmpty(std::string_view key) override {
             count_++;
-            return NOOP;
+            return GetMagicNoOpId();
           }
           int32_t GetCount() const {
             return count_;
@@ -377,33 +377,33 @@ TEST(DBMHashImplTest, CallRecordProcess) {
       static_cast<tkrzw::Compressor*>(&dummy_compressor);
   tkrzw::ScopedStringView placeholder;
   {
-    Checker proc(tkrzw::DBM::RecordProcessor::NOOP);
+    Checker proc(tkrzw::DBM::RecordProcessor::GetMagicNoOpId());
     std::string_view new_value_orig;
     std::string_view new_value = tkrzw::CallRecordProcessFull(
         &proc, "foo", tkrzw::NullableStringView("barbar"), &new_value_orig, nullptr, &placeholder);
-    EXPECT_EQ(tkrzw::DBM::RecordProcessor::NOOP.data(), new_value.data());
+    EXPECT_EQ(tkrzw::DBM::RecordProcessor::GetMagicNoOpId().data(), new_value.data());
     EXPECT_EQ("foo", proc.GetKey());
     EXPECT_EQ("barbar", proc.GetValue());
     new_value = tkrzw::CallRecordProcessEmpty(
         &proc, "boo", &new_value_orig, nullptr, &placeholder);
-    EXPECT_EQ(tkrzw::DBM::RecordProcessor::NOOP.data(), new_value.data());
+    EXPECT_EQ(tkrzw::DBM::RecordProcessor::GetMagicNoOpId().data(), new_value.data());
     EXPECT_EQ("boo", proc.GetKey());
     EXPECT_EQ("", proc.GetValue());
   }
   {
-    Checker proc(tkrzw::DBM::RecordProcessor::NOOP);
+    Checker proc(tkrzw::DBM::RecordProcessor::GetMagicNoOpId());
     size_t comp_size = 0;
     char* comp_data = compressor->Compress("barbar", 6, &comp_size);
     std::string_view new_value_orig;
     std::string_view new_value = tkrzw::CallRecordProcessFull(
         &proc, "foo", tkrzw::NullableStringView(comp_data, comp_size), &new_value_orig,
         compressor, &placeholder);
-    EXPECT_EQ(tkrzw::DBM::RecordProcessor::NOOP.data(), new_value.data());
+    EXPECT_EQ(tkrzw::DBM::RecordProcessor::GetMagicNoOpId().data(), new_value.data());
     EXPECT_EQ("foo", proc.GetKey());
     EXPECT_EQ("barbar", proc.GetValue());
     new_value = tkrzw::CallRecordProcessEmpty(
         &proc, "boo", &new_value_orig, compressor, &placeholder);
-    EXPECT_EQ(tkrzw::DBM::RecordProcessor::NOOP.data(), new_value.data());
+    EXPECT_EQ(tkrzw::DBM::RecordProcessor::GetMagicNoOpId().data(), new_value.data());
     EXPECT_EQ("boo", proc.GetKey());
     EXPECT_EQ("", proc.GetValue());
     tkrzw::xfree(comp_data);

--- a/tkrzw_dbm_hash_test.cc
+++ b/tkrzw_dbm_hash_test.cc
@@ -928,12 +928,12 @@ void HashDBMTest::HashDBMUpdateAppendingTest(tkrzw::HashDBM* dbm) {
    public:
     std::string_view ProcessFull(std::string_view key, std::string_view value) override {
       if (tkrzw::StrToInt(key) % 2 == 0) {
-        return REMOVE;
+        return GetMagicRemoveId();
       }
       return "";
     }
     std::string_view ProcessEmpty(std::string_view key) override {
-      return NOOP;
+      return GetMagicNoOpId();
     }
    private:
     std::string new_value_;
@@ -972,7 +972,7 @@ void HashDBMTest::HashDBMUpdateAppendingTest(tkrzw::HashDBM* dbm) {
    public:
     std::string_view ProcessFull(std::string_view key, std::string_view value) override {
       EXPECT_EQ("*", value);
-      return NOOP;
+      return GetMagicNoOpId();
     }
   } check_proc;
   EXPECT_EQ(tkrzw::Status::SUCCESS, dbm->ProcessEach(&check_proc, false));

--- a/tkrzw_dbm_skip_test.cc
+++ b/tkrzw_dbm_skip_test.cc
@@ -515,15 +515,15 @@ void SkipDBMTest::SkipDBMAdvancedTest(tkrzw::SkipDBM* dbm) {
 TEST_F(SkipDBMTest, Reducer) {
   EXPECT_THAT(tkrzw::SkipDBM::ReduceRemove("", {"a", "b", "c"}), ElementsAre("a", "b", "c"));
   EXPECT_THAT(tkrzw::SkipDBM::ReduceRemove("", {
-        tkrzw::SkipDBM::REMOVING_VALUE}), ElementsAre());
+        tkrzw::SkipDBM::GetMagicRemovingValue()}), ElementsAre());
   EXPECT_THAT(tkrzw::SkipDBM::ReduceRemove("", {
-        tkrzw::SkipDBM::REMOVING_VALUE, "a"}), ElementsAre("a"));
+        tkrzw::SkipDBM::GetMagicRemovingValue(), "a"}), ElementsAre("a"));
   EXPECT_THAT(tkrzw::SkipDBM::ReduceRemove("", {
-        "a", tkrzw::SkipDBM::REMOVING_VALUE, "b"}), ElementsAre("b"));
+        "a", tkrzw::SkipDBM::GetMagicRemovingValue(), "b"}), ElementsAre("b"));
   EXPECT_THAT(tkrzw::SkipDBM::ReduceRemove("", {
-        "a", "b", tkrzw::SkipDBM::REMOVING_VALUE}), ElementsAre());
+        "a", "b", tkrzw::SkipDBM::GetMagicRemovingValue()}), ElementsAre());
   EXPECT_THAT(tkrzw::SkipDBM::ReduceRemove("", {
-        "a", "b", tkrzw::SkipDBM::REMOVING_VALUE, "c", "d"}), ElementsAre("c", "d"));
+        "a", "b", tkrzw::SkipDBM::GetMagicRemovingValue(), "c", "d"}), ElementsAre("c", "d"));
   EXPECT_THAT(tkrzw::SkipDBM::ReduceToFirst("", {"a", "b", "c"}), ElementsAre("a"));
   EXPECT_THAT(tkrzw::SkipDBM::ReduceToSecond("", {"a"}), ElementsAre("a"));
   EXPECT_THAT(tkrzw::SkipDBM::ReduceToSecond("", {"a", "b", "c"}), ElementsAre("b"));
@@ -598,11 +598,11 @@ void SkipDBMTest::SkipDBMProcessTest(tkrzw::SkipDBM* dbm) {
    public:
     std::string_view ProcessFull(std::string_view key, std::string_view value) override {
       count_full_++;
-      return NOOP;
+      return GetMagicNoOpId();
     }
     std::string_view ProcessEmpty(std::string_view key) override {
       count_empty_++;
-      return NOOP;
+      return GetMagicNoOpId();
     }
     int64_t CountFull() {
       return count_full_;
@@ -669,11 +669,11 @@ void SkipDBMTest::SkipDBMProcessTest(tkrzw::SkipDBM* dbm) {
         : records_(records), num_empty_calls_(num_empty_calls) {}
     std::string_view ProcessFull(std::string_view key, std::string_view value) override {
       records_->emplace(key, value);
-      return REMOVE;
+      return GetMagicRemoveId();
     }
     std::string_view ProcessEmpty(std::string_view key) override {
       (*num_empty_calls_)++;
-      return NOOP;
+      return GetMagicNoOpId();
     }
    private:
     std::map<std::string, std::string>* records_;
@@ -685,7 +685,7 @@ void SkipDBMTest::SkipDBMProcessTest(tkrzw::SkipDBM* dbm) {
     std::string_view ProcessFull(std::string_view key, std::string_view value) override {
       last_key_ = key;
       last_value_ = value;
-      return NOOP;
+      return GetMagicNoOpId();
     }
     std::string LastKey() const {
       return last_key_;

--- a/tkrzw_file_test_common.h
+++ b/tkrzw_file_test_common.h
@@ -90,7 +90,7 @@ void CommonFileTest::SmallFileTest(tkrzw::File* file) {
     }
     total_data += data;
     if (file->IsMemoryMapping()) {
-      EXPECT_EQ(tkrzw::AlignNumber(total_data.size(), tkrzw::PAGE_SIZE),
+      EXPECT_EQ(tkrzw::AlignNumber(total_data.size(), tkrzw::GetPageSize()),
                 tkrzw::GetFileSize(file_path));
     } else {
       EXPECT_EQ(total_data.size(), tkrzw::GetFileSize(file_path));
@@ -108,7 +108,7 @@ void CommonFileTest::SmallFileTest(tkrzw::File* file) {
   EXPECT_EQ(total_data, std::string_view(buf, total_data.size()));
   EXPECT_EQ(tkrzw::Status::SUCCESS, file->Truncate(5));
   if (file->IsMemoryMapping()) {
-    EXPECT_EQ(tkrzw::PAGE_SIZE, tkrzw::GetFileSize(file_path));
+    EXPECT_EQ(tkrzw::GetPageSize(), tkrzw::GetFileSize(file_path));
   } else {
     EXPECT_EQ(5, tkrzw::GetFileSize(file_path));
   }

--- a/tkrzw_lib_common.cc
+++ b/tkrzw_lib_common.cc
@@ -18,6 +18,14 @@
 
 namespace tkrzw {
 
+int32_t GetMaxNumberBufferSize() {
+  return NUM_BUFFER_SIZE;
+}
+
+int64_t GetMaxMemorySize() {
+  return MAX_MEMORY_SIZE;
+}
+
 int32_t GetPageSize()
 {
   #if defined(_SYS_WINDOWS_)

--- a/tkrzw_lib_common.h
+++ b/tkrzw_lib_common.h
@@ -142,6 +142,12 @@ extern const bool IS_POSIX;
 /** True if the byte order is big endian. */
 extern const bool IS_BIG_ENDIAN;
 
+/** The buffer size for a numeric string expression. */
+int32_t GetMaxNumberBufferSize();
+
+/** The maximum memory size. */
+int64_t GetMaxMemorySize();
+
 /** The size of a memory page on the OS. */
 int32_t GetPageSize();
 

--- a/tkrzw_lib_common_test.cc
+++ b/tkrzw_lib_common_test.cc
@@ -47,18 +47,18 @@ TEST(LibCommonTest, Constants) {
   EXPECT_GT(tkrzw::DOUBLEMAX, tkrzw::INT64MAX);
   EXPECT_TRUE(std::isnan(tkrzw::DOUBLENAN));
   EXPECT_TRUE(std::isinf(tkrzw::DOUBLEINF));
-  EXPECT_GE(tkrzw::NUM_BUFFER_SIZE, 22);
-  EXPECT_GE(tkrzw::MAX_MEMORY_SIZE, 1LL << 32);
-  EXPECT_GE(tkrzw::PAGE_SIZE, 256);
-  EXPECT_GT(std::strlen(tkrzw::PACKAGE_VERSION), 0);
-  EXPECT_GT(std::strlen(tkrzw::LIBRARY_VERSION), 0);
-  EXPECT_GT(std::strlen(tkrzw::OS_NAME), 0);
+  EXPECT_GE(tkrzw::GetMaxNumberBufferSize(), 22);
+  EXPECT_GE(tkrzw::GetMaxMemorySize(), 1LL << 32);
+  EXPECT_GE(tkrzw::GetPageSize(), 256);
+  EXPECT_GT(std::strlen(tkrzw::GetPackageVersion()), 0);
+  EXPECT_GT(std::strlen(tkrzw::GetLibraryVersion()), 0);
+  EXPECT_GT(std::strlen(tkrzw::GetOsName()), 0);
 }
 
 TEST(LibCommonTest, ByteOrder) {
   const uint32_t num = 0xDEADBEEF;
   const uint8_t* const bytes = reinterpret_cast<const uint8_t*>(&num);
-  if (tkrzw::IS_BIG_ENDIAN) {
+  if (tkrzw::GetIsBigEndian()) {
     EXPECT_EQ(0xDE, bytes[0]);
     EXPECT_EQ(0xAD, bytes[1]);
     EXPECT_EQ(0xBE, bytes[2]);

--- a/tkrzw_sys_config_test.cc
+++ b/tkrzw_sys_config_test.cc
@@ -58,7 +58,7 @@ TEST(SysConfigTest, AlignNumberPowTwo) {
 }
 
 TEST(SysConfigTest, ByteOrders) {
-  if (tkrzw::IS_BIG_ENDIAN) {
+  if (tkrzw::GetIsBigEndian()) {
     EXPECT_EQ(0x1122, tkrzw::HostToNet16(0x1122));
     EXPECT_EQ(0x1122, tkrzw::NetToHost16(0x1122));
     EXPECT_EQ(0x11223344, tkrzw::HostToNet32(0x11223344));

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "tkrzw",
+  "version-string": "1.0.32",
+  "dependencies": [
+    "gtest"
+  ]
+}


### PR DESCRIPTION
Build and execute unit tests, with the exception of `tkrzw_langc_test` which has just too many global variable accesses to get them all.